### PR TITLE
Typo fixes (fixes issue #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /doc/
 .lein-repl-history
 /tmp/
+.nrepl*

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ which is also implemented for strings and byte arrays.
 
 (let [gtlds (dns/domain-set "com" "net" "org")]
   (get gtlds "example.com") ;;=> (#dns/domain "com")
-  (get gtld "does.not.exist") ;;=> nil
+  (get gtlds "does.not.exist") ;;=> nil
   )
 ```
 

--- a/src/clojure/inet/data/dns.clj
+++ b/src/clojure/inet/data/dns.clj
@@ -28,6 +28,8 @@ given domain."
   (^:private -domain [dom]
     "Produce a DNSDomain from `dom`."))
 
+(declare domain)
+
 (defprotocol ^:no-doc DNSDomainOperations
   "Operations on objects which may be treated as domains."
   (^:private -domain? [dom]

--- a/src/clojure/inet/data/ip.clj
+++ b/src/clojure/inet/data/ip.clj
@@ -88,6 +88,11 @@
 
 (ns-unmap *ns* '->IPAddress)
 
+(defn address
+  "The IP address for representation `addr`."
+  {:tag `IPAddress}
+  [addr] (-address addr))
+
 ;; BigInteger mapping is internal-only.  BigInteger doesn't preserve the input
 ;; byte-array size, so we need to prepend a pseudo-magic prefix to retain the
 ;; address length.
@@ -201,11 +206,6 @@ from the final address at -1."
   (network-length [this] length))
 
 (ns-unmap *ns* '->IPNetwork)
-
-(defn address
-  "The IP address for representation `addr`."
-  {:tag `IPAddress}
-  [addr] (-address addr))
 
 (defn ^:private address*
   [orig ^bytes bytes]


### PR DESCRIPTION
Per issue #3, requiring `inet.data.ip` throws an exception related to a couple of typos where `address` should be `-address`.

Similarly, requiring `inet.data.dns` throws an exception related to a typo where `domain` should be `-domain`.

This PR corrects these typos, as well as a minor one in one of the code examples in the README.

Great library, by the way! It is really coming in handy on a particular project I'm working on at work. :+1: 

EDIT: Per discussion on #3, we will instead solve this issue by defining/declaring the `domain` and `address` protocol wrappers earlier.
